### PR TITLE
Error Message Enhancments

### DIFF
--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -41,7 +41,6 @@ pub struct ErrorResponse{
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorDetail{
     message: String,
-    #[serde(default)]
     type_:String,
     param:Option<String>,
     code:Option<String>,

--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -41,6 +41,7 @@ pub struct ErrorResponse{
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorDetail{
     message: String,
+    #[serde(default)]
     type_:String,
     param:Option<String>,
     code:Option<String>,


### PR DESCRIPTION
I hope you're doing well! I wanted to contribute a small enhancement to the cgip package. Before I dive in, I want to mention that I'm certainly a beginner in Rust so this is just good practice for me if not anything else.

After attempting to use the package and adding my API key, I noticed a recurring error message:


```
thread 'main' panicked at /home/anna/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cgip-0.2.1/src/chatgpt.rs:169:62:
called `Result::unwrap()` on an `Err` value: Error("missing field `id`", line: 8, column: 1)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


Upon investigating the code, I realized that the error handling could be improved. Specifically, the package was panicking without providing any helpful information to the user about why parsing failed.

Further analysis revealed that the package returned a JSON string like:


```
{
    "error": {
        "message": "The model `gpt-4` does not exist or you do not have access to it.",
        "type": "invalid_request_error",
        "param": null,
        "code": "model_not_found"
    }
}
```

To address this issue, I've made some modifications to the error handling logic. Now, when encountering these types of errors, the panic message includes the relevant error message, providing users with more useful information.

Here's the new resulting error message:


```
thread 'main' panicked at src/chatgpt.rs:205:21:
Error while parsing response object: The model `gpt-4` does not exist or you do not have access to it.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

On another note, its time for me to pay for ChatGPT to get it working :laughing:.

Best regards,
Anna
