### PR TITLE
Feedback request - Added models and list models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Chat Gipity
 [![crates.io](https://img.shields.io/crates/v/cgip.svg)](https://crates.io/crates/cgip)
 
-Chat gipity is a command line client for ChatGPT. It allows you to chat with the 
-GPT-4 model in a terminal and even pipe output into it.
+Chat gipity is a command line client for ChatGPT. It allows you to chat with your chosen model of ChatGPT in a terminal and even pipe output into it. The default model is GPT-4.
 
 For example, say you wanted to debug your rust program that doesnt compile and 
 want ChatGPT to explain it, you can pipe the output through chat-gipityto help you
@@ -14,7 +13,7 @@ Another usage is reading from a file. In this example we read from a file and as
 ChatGPT to convert that file to another programming language:
 
 ```sh
-cgip -q "convert this to python" -f src/main.rs
+cgip "convert this to python" -f src/main.rs
 ```
 
 # Installation

--- a/src/args.rs
+++ b/src/args.rs
@@ -33,11 +33,19 @@ pub struct Args {
     #[arg(short, long)]
     pub file: Option<String>,
 
+    /// The model to use. Defaults to `gpt-4`
+    #[arg(short = 'o', long)]
+    pub model: Option<String>,
+    
+    /// List the available models
+    #[arg(short = 'l', long)]
+    pub list_models:bool,
+
     /// Show progress indicator (might mess up stdout)
     #[arg(short = 'p', long)]
     pub show_progress: bool,
     
-    /// Prints not only the output from OpenAI but the chat context wiht all
+    /// Prints not only the output from OpenAI but the chat context with all
     /// assistant and user messages.
     #[arg(short = 'c',long)]
     pub show_context: bool,

--- a/src/args.rs
+++ b/src/args.rs
@@ -34,11 +34,11 @@ pub struct Args {
     pub file: Option<String>,
 
     /// The model to use. Defaults to `gpt-4`
-    #[arg(short = 'o', long)]
+    #[arg(short = 'M', long)]
     pub model: Option<String>,
     
     /// List the available models
-    #[arg(short = 'l', long)]
+    #[arg(short, long)]
     pub list_models:bool,
 
     /// Show progress indicator (might mess up stdout)

--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -144,7 +144,7 @@ impl GptClient {
     }
 
     //complete method
-    pub fn complete(&mut self) -> String {
+    pub fn complete(&mut self, model: &str) -> String {
         // Retrieve the API key from the environment variable
         let api_key =
             env::var("OPENAI_API_KEY").expect("Missing OPENAI_API_KEY environment variable");
@@ -165,7 +165,7 @@ impl GptClient {
         headers.insert(header::AUTHORIZATION, auth_header);
 
         let chat_request = ChatRequest {
-            model: "gpt-4".to_string(),
+            model: model.to_string(),
             messages: self.messages.clone(),
         };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,14 +8,25 @@ use crate::{
 pub fn run(args: &Args, client: &mut GptClient) {
     let response_text: String;
 
+    let models = vec!["gpt-3.5-turbo", "gpt-4", "gpt-4-turbo"];
+
+    if args.list_models {
+        for model in models {
+            println!("{}", model);
+        }
+        return;
+    }
+
+    let model_to_use = args.model.as_deref().unwrap_or("gpt-4");
+
     if args.show_progress {
         let mut sp = Spinner::new(Spinners::Dots9, "Thinking...".into());
-        response_text = client.complete();
+        response_text = client.complete(model_to_use);
         sp.stop();
         print!("\x1B[2K"); // Clear the current line
         print!("\r"); // Move the cursor to the beginning of the current line
     } else {
-        response_text = client.complete();
+        response_text = client.complete(model_to_use);
     }
 
     if args.show_context {


### PR DESCRIPTION
Relating to #15

- Modified README to account for the model changes. Also I saw that you had an example using an **old option -q** (I think??) that is now implemented as the argument so I modified it.
- Added **model** and **list_models** to Args struct using flags -o and -l. 
- When using list_models option, the program never executes the GPT client despite other args or options. I did this on purpose. Does that make sense to you?
- Had the complete function now take a new param **model** that is the string input of the -o flag
-  **gpt-3.5-turbo**, **gpt-4**, and **gpt-4-turbo** in list_models, I am defaulting to gpt-4 and have no user set default like I mentioned on the issue but that could be added
- If you input an incorrect model to the -o option you get the following, does this seem like good default behavior?
```
thread 'main' panicked at src/chatgpt.rs:198:21:
Error while parsing response object: The model `gpt-3000` does not exist or you do not have access to it.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
- I noticed some kinda wonky responses on both current version and my modified version when no file or query are given. Not sure exactly why other than GPT is just getting the prompts and sometime replies differently. Maybe this should be an error? I know this is perhaps a different issue (or not one at all).