### PR TITLE
Config file and config subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
+name = "async-trait"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +131,18 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -152,11 +175,15 @@ dependencies = [
  "anyhow",
  "atty",
  "clap",
+ "config",
+ "dirs",
  "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
  "spinners",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -206,6 +233,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "config"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +296,71 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -331,6 +472,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +522,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -511,6 +679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +700,16 @@ name = "libc"
 version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -559,6 +748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +789,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -656,10 +861,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -695,6 +967,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -735,6 +1018,28 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags 2.5.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -841,6 +1146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +1176,17 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -984,6 +1309,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1392,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1457,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1488,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "url"
@@ -1111,6 +1517,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -1363,6 +1775,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 spinners = "4.1.0"
 serde_yaml = "0.8"
+dirs = "5.0.1"
+config = "0.14.0"
+toml = "0.8.12"
+tempfile = "3.10.1"

--- a/src/args.rs
+++ b/src/args.rs
@@ -6,25 +6,24 @@ use clap::{command, Parser};
     version, 
     about, 
     long_about = r###"
-Queries can be piped in through stdin and will be added to the context
-first. 
+cgip is a command-line tool that leverages OpenAI's models to address and 
+respond to user queries. It compiles context for these queries by prioritizing 
+input in a specific order: stdin, command-line arguments, and then files which 
+require you using the -f flag. 
 
-The query passed in as the first argument will then be added to the context
-second.
-
-Files read using -f will be added last to the context.
+The config file will be located in your config directory under cgip/config.toml.
+Please edit this file or use `cgip config --set key=value` to set your configuration.
 
 Usage examples:
 - To pipe input in from ls, run `ls | cgip "what can you tell me about these files?"`
   This will pipe the output of ls in as the first bit of context and then add the user
   query to the context.
 
-More detailed information can go here.
 "###
 )]
 pub struct Args {
-    /// What you want to ask Chat GPT. Query is optional but is added to the prompt
-    /// after the contents of the file or stdin if present.
+    /// Optional. The primary query to sent to the model. 
+    /// This is added to the context after stdin and file input.
     #[arg(index=1)]
     pub query: Option<String>,
 
@@ -33,20 +32,20 @@ pub struct Args {
     #[arg(short, long)]
     pub file: Option<String>,
 
-    /// The model to use. Defaults to `gpt-4`
+    /// Specify model to use. Defaults to `gpt-4`.
     #[arg(short = 'M', long)]
     pub model: Option<String>,
     
-    /// List the available models
+    /// List all the available models. 
     #[arg(short, long)]
     pub list_models:bool,
 
-    /// Show progress indicator (might mess up stdout)
+    /// Show progress indicator (might mess up stdout).
     #[arg(short = 'p', long)]
     pub show_progress: bool,
     
-    /// Prints not only the output from OpenAI but the chat context with all
-    /// assistant and user messages.
+    /// Output the full context used in the query, including chat context with
+    /// all assistant and user messages.
     #[arg(short = 'c',long)]
     pub show_context: bool,
     
@@ -62,7 +61,7 @@ pub struct Args {
 pub enum SubCommands {
     /// Render the context without running a query against the model.
     View(ViewSubCommand),
-    /// Set or get configuration values.
+    /// Set or get default configuration values with your config.toml.
     Config(ConfigSubCommand),
 }
 
@@ -75,11 +74,13 @@ pub struct ViewSubCommand {
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Set or get configuration values", long_about = None)]
 pub struct ConfigSubCommand {
-    /// Set a configuration value in your config.toml 
+    /// Set a configuration value. Use the format key=value.
+    /// `cgip config --set model=gpt-4-turbo`
     #[arg(short, long)]
     pub set: Option<String>,
 
-    /// Get your current configuration value
+    /// Get your current configuration value. 
+    /// `cgip config --get model`
     #[arg(short, long)]
     pub get: Option<String>,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -75,11 +75,11 @@ pub struct ViewSubCommand {
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Set or get configuration values", long_about = None)]
 pub struct ConfigSubCommand {
-    /// Set a configuration value in the application.
+    /// Set a configuration value in your config.toml 
     #[arg(short, long)]
     pub set: Option<String>,
 
-    /// Get a configuration value from the application.
+    /// Get your current configuration value
     #[arg(short, long)]
     pub get: Option<String>,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -61,11 +61,25 @@ pub struct Args {
 #[derive(Parser, Debug)]
 pub enum SubCommands {
     /// Render the context without running a query against the model.
-    View(ViewSubCommand)
+    View(ViewSubCommand),
+    /// Set or get configuration values.
+    Config(ConfigSubCommand),
 }
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct ViewSubCommand {
     // You can add options and arguments specific to the `view` subcommand here.
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Set or get configuration values", long_about = None)]
+pub struct ConfigSubCommand {
+    /// Set a configuration value in the application.
+    #[arg(short, long)]
+    pub set: Option<String>,
+
+    /// Get a configuration value from the application.
+    #[arg(short, long)]
+    pub get: Option<String>,
 }

--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -170,8 +170,12 @@ impl GptClient {
 
         match key {
             "model" => config.model = value.to_string(),
-            "show_progress" => config.show_progress = value.parse().expect("Invalid value for show_progress"),
-            "show_context" => config.show_context = value.parse().expect("Invalid value for show_context"),
+            "show_progress" => {
+                config.show_progress = value.parse().expect("Invalid value for show_progress")
+            }
+            "show_context" => {
+                config.show_context = value.parse().expect("Invalid value for show_context")
+            }
             "markdown" => config.markdown = value.parse().expect("Invalid value for markdown"),
             _ => eprintln!("Invalid configuration key"),
         }
@@ -179,7 +183,8 @@ impl GptClient {
         let contents = toml::to_string(&config).expect("Failed to serialize config");
         let config_path = cd.join("config.toml");
         let mut file = File::create(&config_path).expect("Failed to create config file");
-        file.write_all(contents.as_bytes()).expect("Failed to write to config file");
+        file.write_all(contents.as_bytes())
+            .expect("Failed to write to config file");
     }
     pub fn get_config_value(&self, key: &str) -> String {
         match key {
@@ -313,7 +318,6 @@ impl GptClient {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -329,7 +333,6 @@ mod tests {
             show_progress: true,
             show_context: false,
             markdown: false,
-
         };
         let config_path = config_dir_path.join("config.toml");
         let contents = toml::to_string(&custom_config).expect("Failed to serialize custom config");
@@ -344,10 +347,7 @@ mod tests {
             config.model, "gpt-3.5-turbo",
             "Model should be 'gpt-3.5-turbo'"
         );
-        assert_eq!(
-            config.show_progress, true,
-            "show_progress should be true"
-        );
+        assert_eq!(config.show_progress, true, "show_progress should be true");
     }
     #[test]
     fn test_custom_config_with_missing() {
@@ -364,14 +364,8 @@ mod tests {
 
         let config = GptClient::load_config(&config_dir_path);
         // maintain default values for missing fields
-        assert_eq!(
-            config.model, "gpt-4",
-            "Model should be 'gpt-4'"
-        );
-        assert_eq!(
-            config.show_progress, true,
-            "show_progress should be true"
-        );
+        assert_eq!(config.model, "gpt-4", "Model should be 'gpt-4'");
+        assert_eq!(config.show_progress, true, "show_progress should be true");
     }
     #[test]
     fn test_default_config() {
@@ -388,5 +382,4 @@ mod tests {
             "show_progress should default to false"
         );
     }
-
 }

--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -1,36 +1,12 @@
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::{env, fmt};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Result;
-use toml;
 use dirs::config_dir;
 use reqwest::header;
 
-use config::{Config, File as ConfigFile, FileFormat};
-use crate::utils::ensure_config_file;
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct AppConfig {
-    pub model: String,
-    pub show_progress: bool,
-    pub show_context: bool,
-    pub markdown: bool,
-}
-
-impl Default for AppConfig {
-    fn default() -> Self {
-        Self {
-            model: "gpt-4".to_string(),
-            show_progress: false,
-            show_context: false,
-            markdown: false,
-        }
-    }
-}
+use crate::config_manager::ConfigManager;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ChatRequest {
@@ -93,8 +69,7 @@ fn parse_error_response(json_str: &str) -> Result<ErrorResponse> {
 }
 
 pub struct GptClient {
-    pub config: AppConfig,
-    pub config_directory: PathBuf,
+    pub config_manager: ConfigManager,
     pub messages: Vec<Message>,
 }
 
@@ -128,77 +103,12 @@ impl fmt::Display for Role {
 }
 
 impl GptClient {
-    pub fn setup_config(dir: &PathBuf) {
-        if let Err(e) = ensure_config_file(dir) {
-            panic!("Failed to ensure config file exists: {}", e);
-        }
-    }
-
-    pub fn load_config(dir: &PathBuf) -> AppConfig {
-        let config_path = dir.join("config.toml");
-        let defaults = Config::try_from(&AppConfig::default()).unwrap();
-        let config = Config::builder() // sources will be merged by priority
-            .add_source(defaults)
-            .add_source(ConfigFile::new(
-                config_path.to_str().unwrap(),
-                FileFormat::Toml,
-            ))
-            .build()
-            .unwrap();
-        let loaded_config = config
-            .try_deserialize::<AppConfig>()
-            .expect("Failed to deserialize config");
-
-        loaded_config
-    }
-
-    pub fn set_config_value(&mut self, key: &str, value: &str) {
-        let config_path = match ensure_config_file(&self.config_directory) {
-            Ok(path) => path,
-            Err(e) => panic!("Failed to ensure config file exists: {}", e),
-        };
-
-        let mut config = if self.config_directory.exists() {
-            Self::load_config(&self.config_directory)
-        } else {
-            AppConfig::default()
-        };
-
-        match key {
-            "model" => config.model = value.to_string(),
-            "show_progress" => {
-                config.show_progress = value.parse().expect("Invalid value for show_progress")
-            }
-            "show_context" => {
-                config.show_context = value.parse().expect("Invalid value for show_context")
-            }
-            "markdown" => config.markdown = value.parse().expect("Invalid value for markdown"),
-            _ => eprintln!("Invalid configuration key"),
-        }
-
-        let contents = toml::to_string(&config).expect("Failed to serialize config");
-        let mut file = File::create(&config_path).expect("Failed to create config file");
-        file.write_all(contents.as_bytes())
-            .expect("Failed to write to config file");
-    }
-
-    pub fn get_config_value(&self, key: &str) -> String {
-        match key {
-            "model" => self.config.model.clone(),
-            "show_progress" => self.config.show_progress.to_string(),
-            "show_context" => self.config.show_context.to_string(),
-            "markdown" => self.config.markdown.to_string(),
-            _ => "Invalid configuration key".to_string(),
-        }
-    }
-
     pub fn new() -> Self {
         let config_directory = config_dir()
             .expect("Failed to find config directory")
             .join("cgip");
 
-        Self::setup_config(&config_directory);
-        let config = Self::load_config(&config_directory);
+        let config_manager = ConfigManager::new(config_directory);
 
         let os = env::consts::OS;
 
@@ -214,8 +124,7 @@ impl GptClient {
         );
 
         GptClient {
-            config,
-            config_directory,
+            config_manager,
             messages: vec![Message {
                 role: Role::System.to_string().to_lowercase(),
                 content: system_prompt.trim().to_string(),
@@ -267,7 +176,7 @@ impl GptClient {
         headers.insert(header::AUTHORIZATION, auth_header);
 
         let chat_request = ChatRequest {
-            model: self.config.model.clone(),
+            model: self.config_manager.config.model.clone(),
             messages: self.messages.clone(),
         };
 
@@ -320,64 +229,63 @@ mod tests {
     use std::io::Write;
     use tempfile::TempDir;
 
+    use crate::config_manager::AppConfig;
+
     #[test]
     fn test_custom_config() {
         let temp_dir = TempDir::new().unwrap();
         let config_dir_path = temp_dir.path().join("cgip");
-        GptClient::setup_config(&config_dir_path);
+        let mut config_manager = ConfigManager::new(config_dir_path.clone());
+
+        // Manually create a custom config
         let custom_config = AppConfig {
             model: "gpt-3.5-turbo".to_string(),
             show_progress: true,
             show_context: false,
             markdown: false,
         };
+
+        // Serialize and save this custom config
         let config_path = config_dir_path.join("config.toml");
         let contents = toml::to_string(&custom_config).expect("Failed to serialize custom config");
+        let mut file = File::create(&config_path).expect("Failed to open config file");
+        file.write_all(contents.as_bytes()).expect("Failed to write custom config to file");
 
-        let mut file = File::create(&config_path)
-            .expect("Failed to open config file for writing custom settings");
-        file.write_all(contents.as_bytes())
-            .expect("Failed to write custom config to file");
+        // Reload config from file
+        config_manager.config = ConfigManager::load_config(&config_dir_path);
 
-        let config = GptClient::load_config(&config_dir_path);
-        assert_eq!(
-            config.model, "gpt-3.5-turbo",
-            "Model should be 'gpt-3.5-turbo'"
-        );
-        assert_eq!(config.show_progress, true, "show_progress should be true");
+        assert_eq!(config_manager.config.model, "gpt-3.5-turbo", "Model should be 'gpt-3.5-turbo'");
+        assert_eq!(config_manager.config.show_progress, true, "show_progress should be true");
     }
+
     #[test]
     fn test_custom_config_with_missing() {
         let temp_dir = TempDir::new().unwrap();
         let config_dir_path = temp_dir.path().join("cgip");
-        GptClient::setup_config(&config_dir_path);
+        let mut config_manager = ConfigManager::new(config_dir_path.clone());
+
+        // Create a partial config file manually
         let config_path = config_dir_path.join("config.toml");
-
         let contents = "show_progress = true";
-        let mut file = File::create(&config_path)
-            .expect("Failed to open config file for writing custom settings");
-        file.write_all(contents.as_bytes())
-            .expect("Failed to write custom config to file");
+        let mut file = File::create(&config_path).expect("Failed to open config file");
+        file.write_all(contents.as_bytes()).expect("Failed to write partial config to file");
 
-        let config = GptClient::load_config(&config_dir_path);
-        // maintain default values for missing fields
-        assert_eq!(config.model, "gpt-4", "Model should be 'gpt-4'");
-        assert_eq!(config.show_progress, true, "show_progress should be true");
+        // Reload config from file
+        config_manager.config = ConfigManager::load_config(&config_dir_path);
+
+        assert_eq!(config_manager.config.model, "gpt-4", "Model should default to 'gpt-4'");
+        assert_eq!(config_manager.config.show_progress, true, "show_progress should be true");
     }
+
     #[test]
     fn test_default_config() {
         let temp_dir = TempDir::new().unwrap();
         let config_dir_path = temp_dir.path().join("cgip");
+        let config_manager = ConfigManager::new(config_dir_path);
 
-        GptClient::setup_config(&config_dir_path);
-
-        let config = GptClient::load_config(&config_dir_path);
-
-        assert_eq!(config.model, "gpt-4", "Model should default to 'gpt-4'");
-        assert_eq!(
-            config.show_progress, false,
-            "show_progress should default to false"
-        );
+        assert_eq!(config_manager.config.model, "gpt-4", "Model should default to 'gpt-4'");
+        assert_eq!(config_manager.config.show_progress, false, "show_progress should default to false");
     }
+
 
 }

--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 use std::{env, fmt};
 
-use serde::{Deserialize, Serialize};
-use serde_json::Result;
 use dirs::config_dir;
 use reqwest::header;
+use serde::{Deserialize, Serialize};
+use serde_json::Result;
 
 use crate::config_manager::ConfigManager;
 
@@ -220,72 +220,4 @@ impl GptClient {
         self.add_message(Role::Assistant, result.clone());
         result
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs::File;
-    use std::io::Write;
-    use tempfile::TempDir;
-
-    use crate::config_manager::AppConfig;
-
-    #[test]
-    fn test_custom_config() {
-        let temp_dir = TempDir::new().unwrap();
-        let config_dir_path = temp_dir.path().join("cgip");
-        let mut config_manager = ConfigManager::new(config_dir_path.clone());
-
-        // Manually create a custom config
-        let custom_config = AppConfig {
-            model: "gpt-3.5-turbo".to_string(),
-            show_progress: true,
-            show_context: false,
-            markdown: false,
-        };
-
-        // Serialize and save this custom config
-        let config_path = config_dir_path.join("config.toml");
-        let contents = toml::to_string(&custom_config).expect("Failed to serialize custom config");
-        let mut file = File::create(&config_path).expect("Failed to open config file");
-        file.write_all(contents.as_bytes()).expect("Failed to write custom config to file");
-
-        // Reload config from file
-        config_manager.config = ConfigManager::load_config(&config_dir_path);
-
-        assert_eq!(config_manager.config.model, "gpt-3.5-turbo", "Model should be 'gpt-3.5-turbo'");
-        assert_eq!(config_manager.config.show_progress, true, "show_progress should be true");
-    }
-
-    #[test]
-    fn test_custom_config_with_missing() {
-        let temp_dir = TempDir::new().unwrap();
-        let config_dir_path = temp_dir.path().join("cgip");
-        let mut config_manager = ConfigManager::new(config_dir_path.clone());
-
-        // Create a partial config file manually
-        let config_path = config_dir_path.join("config.toml");
-        let contents = "show_progress = true";
-        let mut file = File::create(&config_path).expect("Failed to open config file");
-        file.write_all(contents.as_bytes()).expect("Failed to write partial config to file");
-
-        // Reload config from file
-        config_manager.config = ConfigManager::load_config(&config_dir_path);
-
-        assert_eq!(config_manager.config.model, "gpt-4", "Model should default to 'gpt-4'");
-        assert_eq!(config_manager.config.show_progress, true, "show_progress should be true");
-    }
-
-    #[test]
-    fn test_default_config() {
-        let temp_dir = TempDir::new().unwrap();
-        let config_dir_path = temp_dir.path().join("cgip");
-        let config_manager = ConfigManager::new(config_dir_path);
-
-        assert_eq!(config_manager.config.model, "gpt-4", "Model should default to 'gpt-4'");
-        assert_eq!(config_manager.config.show_progress, false, "show_progress should default to false");
-    }
-
-
 }

--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -1,14 +1,17 @@
-use config::{Config, File as ConfigFile, FileFormat};
-use dirs::config_dir;
-use reqwest::header;
-use serde::{Deserialize, Serialize};
-use serde_json::Result;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::{env, fmt};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Result;
 use toml;
+use dirs::config_dir;
+use reqwest::header;
+
+use config::{Config, File as ConfigFile, FileFormat};
+use crate::utils::ensure_config_file;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AppConfig {
@@ -122,19 +125,6 @@ impl fmt::Display for Role {
             Role::Assistant => write!(f, "assistant"),
         }
     }
-}
-
-fn ensure_config_file(dir: &PathBuf) -> std::io::Result<PathBuf> {
-    fs::create_dir_all(dir)?;
-    let config_path = dir.join("config.toml");
-    if !config_path.exists() {
-        let config = AppConfig::default();
-        let contents = toml::to_string(&config).expect("Failed to serialize config");
-        let mut file = File::create(&config_path)?;
-        file.write_all(contents.as_bytes())?;
-    }
-
-    Ok(config_path)
 }
 
 impl GptClient {
@@ -326,8 +316,8 @@ impl GptClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::{self, File};
-    use std::io::{Read, Write};
+    use std::fs::File;
+    use std::io::Write;
     use tempfile::TempDir;
 
     #[test]
@@ -389,53 +379,5 @@ mod tests {
             "show_progress should default to false"
         );
     }
-    #[test]
-    fn test_ensure_config_file() {
-        let temp_dir = TempDir::new().unwrap();
-        let config_dir = temp_dir.path().join("cgip");
 
-        // Scenario 1: Neither directory nor file exists
-        let config_path = ensure_config_file(&config_dir).expect("Failed to ensure config file");
-        assert!(config_path.exists(), "The config file should be created");
-
-        // Check if default content is written
-        let mut contents = String::new();
-        File::open(&config_path)
-            .unwrap()
-            .read_to_string(&mut contents)
-            .unwrap();
-        assert!(
-            contents.contains("gpt-4"),
-            "Default settings should include the model name"
-        );
-
-        // Scenario 2: Directory exists but no config file
-        fs::remove_file(&config_path).unwrap(); // Remove the config file
-        let config_path =
-            ensure_config_file(&config_dir).expect("Failed to ensure config file again");
-        assert!(config_path.exists(), "The config file should be recreated");
-
-        // Scenario 3: Both directory and file exist with custom content
-        let custom_config = AppConfig {
-            model: "custom-model".to_string(),
-            show_progress: true,
-            show_context: true,
-            markdown: true,
-        };
-        let custom_contents = toml::to_string(&custom_config).unwrap();
-        File::create(&config_path)
-            .unwrap()
-            .write_all(custom_contents.as_bytes())
-            .unwrap();
-        ensure_config_file(&config_dir).expect("Failed to ensure config file a third time");
-        contents.clear();
-        File::open(&config_path)
-            .unwrap()
-            .read_to_string(&mut contents)
-            .unwrap();
-        assert!(
-            contents.contains("custom-model"),
-            "The existing custom config should not be overwritten"
-        );
-    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ pub fn run(args: &Args, client: &mut GptClient) {
     let response_text: String;
     // Override model from config if it was provided in args
     if let Some(ref model) = args.model {
-        client.config.model = model.clone();
+        client.config_manager.config.model = model.clone();
     }
 
     // List available models
@@ -19,7 +19,7 @@ pub fn run(args: &Args, client: &mut GptClient) {
     }
 
     // Override show_progress from config if it was provided in args
-    let show_progress = args.show_progress || client.config.show_progress;
+    let show_progress = args.show_progress || client.config_manager.config.show_progress;
 
     if show_progress {
         let mut sp = Spinner::new(Spinners::Dots9, "Thinking...".into());
@@ -31,8 +31,8 @@ pub fn run(args: &Args, client: &mut GptClient) {
         response_text = client.complete();
     }
 
-    let show_context = args.show_context || client.config.show_context;
-    let markdown = args.markdown || client.config.markdown;
+    let show_context = args.show_context || client.config_manager.config.show_context;
+    let markdown = args.markdown || client.config_manager.config.markdown;
 
     if show_context {
         if markdown {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,9 +7,13 @@ use crate::{
 
 pub fn run(args: &Args, client: &mut GptClient) {
     let response_text: String;
+    // Override model from config if it was provided in args
+    if let Some(ref model) = args.model {
+        client.config.model = model.clone();
+    }
 
+    // List available models
     let models = vec!["gpt-3.5-turbo", "gpt-4", "gpt-4-turbo"];
-
     if args.list_models {
         for model in models {
             println!("{}", model);
@@ -17,16 +21,22 @@ pub fn run(args: &Args, client: &mut GptClient) {
         return;
     }
 
-    let model_to_use = args.model.as_deref().unwrap_or("gpt-4");
-
+    // Override show_progress from config if it was provided in args
+    let show_progress: bool;
     if args.show_progress {
+        show_progress = true
+    } else {
+        show_progress = client.config.show_progress;
+    }
+
+    if show_progress {
         let mut sp = Spinner::new(Spinners::Dots9, "Thinking...".into());
-        response_text = client.complete(model_to_use);
+        response_text = client.complete();
         sp.stop();
         print!("\x1B[2K"); // Clear the current line
         print!("\r"); // Move the cursor to the beginning of the current line
     } else {
-        response_text = client.complete(model_to_use);
+        response_text = client.complete();
     }
 
     if args.show_context {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,6 @@
 use spinners::{Spinner, Spinners};
 
-use crate::{
-    args::Args,
-    chatgpt::GptClient, utils::markdown_from_messages,
-};
+use crate::{args::Args, chatgpt::GptClient, utils::markdown_from_messages};
 
 pub fn run(args: &Args, client: &mut GptClient) {
     let response_text: String;
@@ -22,12 +19,7 @@ pub fn run(args: &Args, client: &mut GptClient) {
     }
 
     // Override show_progress from config if it was provided in args
-    let show_progress: bool;
-    if args.show_progress {
-        show_progress = true
-    } else {
-        show_progress = client.config.show_progress;
-    }
+    let show_progress = args.show_progress || client.config.show_progress;
 
     if show_progress {
         let mut sp = Spinner::new(Spinners::Dots9, "Thinking...".into());
@@ -39,8 +31,11 @@ pub fn run(args: &Args, client: &mut GptClient) {
         response_text = client.complete();
     }
 
-    if args.show_context {
-        if args.markdown {
+    let show_context = args.show_context || client.config.show_context;
+    let markdown = args.markdown || client.config.markdown;
+
+    if show_context {
+        if markdown {
             let visible_messages = client
                 .messages
                 .iter()

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -1,0 +1,105 @@
+use std::{fs::File, io::Write, path::PathBuf};
+
+use config::{Config, File as ConfigFile, FileFormat};
+use serde::{Deserialize, Serialize};
+
+use crate::utils::ensure_config_file;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AppConfig {
+    pub model: String,
+    pub show_progress: bool,
+    pub show_context: bool,
+    pub markdown: bool,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            model: "gpt-4".to_string(),
+            show_progress: false,
+            show_context: false,
+            markdown: false,
+        }
+    }
+}
+
+pub struct ConfigManager {
+    pub config: AppConfig,
+    pub config_directory: PathBuf,
+}
+
+impl ConfigManager {
+    pub fn new(config_directory: PathBuf) -> Self {
+        Self::setup_config(&config_directory);
+        let config = Self::load_config(&config_directory);
+        ConfigManager {
+            config,
+            config_directory,
+        }
+    }
+
+    pub fn setup_config(dir: &PathBuf) {
+        if let Err(e) = ensure_config_file(dir) {
+            panic!("Failed to ensure config file exists: {}", e);
+        }
+    }
+
+    pub fn load_config(dir: &PathBuf) -> AppConfig {
+        let config_path = dir.join("config.toml");
+        let defaults = Config::try_from(&AppConfig::default()).unwrap();
+        let config = Config::builder() // sources will be merged by priority
+            .add_source(defaults)
+            .add_source(ConfigFile::new(
+                config_path.to_str().unwrap(),
+                FileFormat::Toml,
+            ))
+            .build()
+            .unwrap();
+        let loaded_config = config
+            .try_deserialize::<AppConfig>()
+            .expect("Failed to deserialize config");
+
+        loaded_config
+    }
+
+    pub fn set_config_value(&mut self, key: &str, value: &str) {
+        let config_path = match ensure_config_file(&self.config_directory) {
+            Ok(path) => path,
+            Err(e) => panic!("Failed to ensure config file exists: {}", e),
+        };
+
+        let mut config = if self.config_directory.exists() {
+            Self::load_config(&self.config_directory)
+        } else {
+            AppConfig::default()
+        };
+
+        match key {
+            "model" => config.model = value.to_string(),
+            "show_progress" => {
+                config.show_progress = value.parse().expect("Invalid value for show_progress")
+            }
+            "show_context" => {
+                config.show_context = value.parse().expect("Invalid value for show_context")
+            }
+            "markdown" => config.markdown = value.parse().expect("Invalid value for markdown"),
+            _ => eprintln!("Invalid configuration key"),
+        }
+
+        let contents = toml::to_string(&config).expect("Failed to serialize config");
+        let mut file = File::create(&config_path).expect("Failed to create config file");
+        file.write_all(contents.as_bytes())
+            .expect("Failed to write to config file");
+    }
+
+    pub fn get_config_value(&self, key: &str) -> String {
+        match key {
+            "model" => self.config.model.clone(),
+            "show_progress" => self.config.show_progress.to_string(),
+            "show_context" => self.config.show_context.to_string(),
+            "markdown" => self.config.markdown.to_string(),
+            _ => "Invalid configuration key".to_string(),
+        }
+    }
+}

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -103,3 +103,89 @@ impl ConfigManager {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    use crate::config_manager::AppConfig;
+
+    #[test]
+    fn test_custom_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir_path = temp_dir.path().join("cgip");
+        let mut config_manager = ConfigManager::new(config_dir_path.clone());
+
+        // Manually create a custom config
+        let custom_config = AppConfig {
+            model: "gpt-3.5-turbo".to_string(),
+            show_progress: true,
+            show_context: false,
+            markdown: false,
+        };
+
+        // Serialize and save this custom config
+        let config_path = config_dir_path.join("config.toml");
+        let contents = toml::to_string(&custom_config).expect("Failed to serialize custom config");
+        let mut file = File::create(&config_path).expect("Failed to open config file");
+        file.write_all(contents.as_bytes())
+            .expect("Failed to write custom config to file");
+
+        // Reload config from file
+        config_manager.config = ConfigManager::load_config(&config_dir_path);
+
+        assert_eq!(
+            config_manager.config.model, "gpt-3.5-turbo",
+            "Model should be 'gpt-3.5-turbo'"
+        );
+        assert_eq!(
+            config_manager.config.show_progress, true,
+            "show_progress should be true"
+        );
+    }
+
+    #[test]
+    fn test_custom_config_with_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir_path = temp_dir.path().join("cgip");
+        let mut config_manager = ConfigManager::new(config_dir_path.clone());
+
+        // Create a partial config file manually
+        let config_path = config_dir_path.join("config.toml");
+        let contents = "show_progress = true";
+        let mut file = File::create(&config_path).expect("Failed to open config file");
+        file.write_all(contents.as_bytes())
+            .expect("Failed to write partial config to file");
+
+        // Reload config from file
+        config_manager.config = ConfigManager::load_config(&config_dir_path);
+
+        assert_eq!(
+            config_manager.config.model, "gpt-4",
+            "Model should default to 'gpt-4'"
+        );
+        assert_eq!(
+            config_manager.config.show_progress, true,
+            "show_progress should be true"
+        );
+    }
+
+    #[test]
+    fn test_default_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir_path = temp_dir.path().join("cgip");
+        let config_manager = ConfigManager::new(config_dir_path);
+
+        assert_eq!(
+            config_manager.config.model, "gpt-4",
+            "Model should default to 'gpt-4'"
+        );
+        assert_eq!(
+            config_manager.config.show_progress, false,
+            "show_progress should default to false"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn is_valid_yaml(yaml_str: &str) -> Result<bool, Error> {
         Err(_) => Ok(false),
     }
 }
+
 fn main() {
     let args = Args::parse();
     let mut client = GptClient::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn handle_config_subcommand(client: &mut chatgpt::GptClient, config_sc: &ConfigS
                 parts[0], parts[1]
             )
         } else {
-            println!("Invalid format for setting configuration. Use key=value");
+            println!("Invalid format for setting configuration. Use cgip config --set key=value");
         }
     }
     if let Some(ref get) = config_sc.get {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod args;
 mod chatgpt;
 mod cli;
 mod utils;
+mod config_manager;
 
 fn main() {
     let mut client = GptClient::new();
@@ -61,7 +62,7 @@ fn handle_config_subcommand(client: &mut chatgpt::GptClient, config_sc: &ConfigS
     if let Some(ref set) = config_sc.set {
         let parts: Vec<&str> = set.split('=').collect();
         if parts.len() == 2 {
-            client.set_config_value(parts[0], parts[1]);
+            client.config_manager.set_config_value(parts[0], parts[1]);
             println!(
                 "Configuration set successfully for {} to {}",
                 parts[0], parts[1]
@@ -71,7 +72,7 @@ fn handle_config_subcommand(client: &mut chatgpt::GptClient, config_sc: &ConfigS
         }
     }
     if let Some(ref get) = config_sc.get {
-        let value = client.get_config_value(get);
+        let value = client.config_manager.get_config_value(get);
         println!("Configuration for {} is {}", get, value);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 
-use args::{Args, SubCommands, ConfigSubCommand};
+use args::{Args, ConfigSubCommand, SubCommands};
 use chatgpt::{GptClient, Message, Role};
 use clap::Parser;
 use cli::run;
-use utils::{get_file_contents_from_path, get_stdin, markdown_from_messages, is_valid_yaml};
+use utils::{get_file_contents_from_path, get_stdin, is_valid_yaml, markdown_from_messages};
 
 mod args;
 mod chatgpt;
@@ -12,15 +12,13 @@ mod cli;
 mod utils;
 
 fn main() {
-
     let mut client = GptClient::new();
     let args = Args::parse();
 
-    if let Some(SubCommands::Config(config_sc)) = &args.subcmd{
+    if let Some(SubCommands::Config(config_sc)) = &args.subcmd {
         handle_config_subcommand(&mut client, config_sc);
         return;
     }
-
 
     let stdin_text = get_stdin();
     if !stdin_text.is_empty() {
@@ -35,8 +33,14 @@ fn main() {
         }
     }
 
-    if let Some(_) = args.subcmd { // If view mode
-        let visible_messages = client.messages.iter().cloned().filter(|msg| msg.role != "system").collect();      
+    if let Some(_) = args.subcmd {
+        // If view mode
+        let visible_messages = client
+            .messages
+            .iter()
+            .cloned()
+            .filter(|msg| msg.role != "system")
+            .collect();
         let md = markdown_from_messages(visible_messages);
         println!("{}", md);
         return;
@@ -58,11 +62,13 @@ fn handle_config_subcommand(client: &mut chatgpt::GptClient, config_sc: &ConfigS
         let parts: Vec<&str> = set.split('=').collect();
         if parts.len() == 2 {
             client.set_config_value(parts[0], parts[1]);
-            println!("Configuration set successfully for {} to {}", parts[0], parts[1])
+            println!(
+                "Configuration set successfully for {} to {}",
+                parts[0], parts[1]
+            )
         } else {
             println!("Invalid format for setting configuration. Use key=value");
         }
-        // Additional logic to set the configuration
     }
     if let Some(ref get) = config_sc.get {
         let value = client.get_config_value(get);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ use atty::Stream;
 use serde_yaml::Error;
 
 use crate::chatgpt::Message;
-use crate::chatgpt::AppConfig;
+use crate::config_manager::AppConfig;
 
 pub fn markdown_from_messages(messages: Vec<Message>) -> String {
     let initial = String::from("");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,18 +1,17 @@
+use atty::Stream;
 use std::{
     fs,
     io::{self, BufRead},
 };
-use atty::Stream;
 
 use crate::chatgpt::Message;
+use serde_yaml::Error;
 
 pub fn markdown_from_messages(messages: Vec<Message>) -> String {
     let initial = String::from("");
-    let md = messages
-        .iter()
-        .fold(initial, |acc, msg| {
-            format!("{}**{}**: {}\n\n", acc, msg.role, msg.content)
-        });
+    let md = messages.iter().fold(initial, |acc, msg| {
+        format!("{}**{}**: {}\n\n", acc, msg.role, msg.content)
+    });
     md
 }
 
@@ -35,6 +34,23 @@ pub fn get_stdin() -> String {
 
 pub fn get_file_contents_from_path(path: String) -> String {
     fs::read_to_string(path).expect("Something went wrong reading the file")
+}
+
+pub fn is_valid_yaml(yaml_str: &str) -> Result<bool, Error> {
+    let messages: Result<Vec<Message>, Error> = serde_yaml::from_str(yaml_str);
+
+    match messages {
+        Ok(msgs) => {
+            for msg in msgs {
+                if msg.role.is_empty() || msg.content.is_empty() {
+                    return Ok(false);
+                }
+                // Add more validation logic if needed
+            }
+            Ok(true)
+        }
+        Err(_) => Ok(false),
+    }
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,16 @@
-use atty::Stream;
 use std::{
     fs,
     io::{self, BufRead},
 };
+use std::path::PathBuf;
+use std::fs::File;
+use std::io::Write;
+
+use atty::Stream;
+use serde_yaml::Error;
 
 use crate::chatgpt::Message;
-use serde_yaml::Error;
+use crate::chatgpt::AppConfig;
 
 pub fn markdown_from_messages(messages: Vec<Message>) -> String {
     let initial = String::from("");
@@ -53,6 +58,28 @@ pub fn is_valid_yaml(yaml_str: &str) -> Result<bool, Error> {
     }
 }
 
+pub fn ensure_config_file(dir: &PathBuf) -> std::io::Result<PathBuf> {
+    fs::create_dir_all(dir)?;
+    let config_path = dir.join("config.toml");
+    if !config_path.exists() {
+        let config = AppConfig::default();
+        let contents = toml::to_string(&config).expect("Failed to serialize config");
+        let mut file = File::create(&config_path)?;
+        file.write_all(contents.as_bytes())?;
+    }
+
+    Ok(config_path)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::io::{Read, Write};
+    use tempfile::TempDir;
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -61,5 +88,57 @@ mod tests {
     fn test_get_file_contents_from_path() {
         let file_contents = get_file_contents_from_path("./test_data/test.txt".to_string());
         assert_eq!(file_contents, "test\n");
+    }
+}
+
+
+    #[test]
+    fn test_ensure_config_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir = temp_dir.path().join("cgip");
+
+        // Scenario 1: Neither directory nor file exists
+        let config_path = ensure_config_file(&config_dir).expect("Failed to ensure config file");
+        assert!(config_path.exists(), "The config file should be created");
+
+        // Check if default content is written
+        let mut contents = String::new();
+        File::open(&config_path)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+        assert!(
+            contents.contains("gpt-4"),
+            "Default settings should include the model name"
+        );
+
+        // Scenario 2: Directory exists but no config file
+        fs::remove_file(&config_path).unwrap(); // Remove the config file
+        let config_path =
+            ensure_config_file(&config_dir).expect("Failed to ensure config file again");
+        assert!(config_path.exists(), "The config file should be recreated");
+
+        // Scenario 3: Both directory and file exist with custom content
+        let custom_config = AppConfig {
+            model: "custom-model".to_string(),
+            show_progress: true,
+            show_context: true,
+            markdown: true,
+        };
+        let custom_contents = toml::to_string(&custom_config).unwrap();
+        File::create(&config_path)
+            .unwrap()
+            .write_all(custom_contents.as_bytes())
+            .unwrap();
+        ensure_config_file(&config_dir).expect("Failed to ensure config file a third time");
+        contents.clear();
+        File::open(&config_path)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+        assert!(
+            contents.contains("custom-model"),
+            "The existing custom config should not be overwritten"
+        );
     }
 }


### PR DESCRIPTION
Addressing #20 

A lot more code than I thought it would take here, also more diffs than I wanted because imports moved around when I ran format on a few files as well. I'm just putting this here so you can give it a quick glance and you can let me know if you see anything glaring I didn't think about, still have some tests I want to add/ double check and clean up some things.

Added config file using paths from dirs, I also used the [config](https://docs.rs/config/latest/config/) crate. I've only tested on Linux as of right now. Big thing I made sure of was the preferences of which arg to use **flag>config file>defaults.** 

Added way to get and set values like **cgip config --set model=gpt-4**

Have a decent number of comments I can probably remove. The test you had and the couple tests I made are all passing and playing with it a bit it _seems_ to still be ok. 

Got quite acquainted with how the borrow checker but I am still not sure if we are friends.
Just v1 for now ~~really v2 don't peek at the branch I frustratingly abandoned after my first hour  of work~~