### PR TITLE
Add embedding subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ The TTS subcommand reads text from command arguments, stdin, or both. When both 
 
 For detailed documentation including voice characteristics, examples, and advanced usage, see [docs/TTS_SUBCOMMAND.md](docs/TTS_SUBCOMMAND.md).
 
+# Embedding Generation
+
+You can generate embedding vectors for text using the `embedding` subcommand.
+Text may be provided as an argument or via stdin. The resulting vector is printed
+to stdout or saved to a file with `--output`.
+
+```sh
+# Basic usage
+cgip embedding "Hello world"
+
+# Read text from stdin and save to file
+echo "some text" | cgip embedding --output vec.txt
+```
+
+See [docs/EMBEDDING_SUBCOMMAND.md](docs/EMBEDDING_SUBCOMMAND.md) for more details.
+
 # Installation
 
 chat-gipitty is designed to be run on POSIX compliant systems, you have mutliple options for installing released versions depending on your system. All systems should be able to install from source or from cargo, but a homebrew tap is also available as well as a debian package attacked to the github releases.

--- a/docs/EMBEDDING_SUBCOMMAND.md
+++ b/docs/EMBEDDING_SUBCOMMAND.md
@@ -1,0 +1,23 @@
+# Embedding Subcommand Documentation
+
+The `embedding` subcommand generates embedding vectors for a piece of text using OpenAI-compatible embedding models.
+
+## Basic Usage
+
+```bash
+cgip embedding "Hello, world"
+```
+
+Text can also be provided via stdin:
+
+```bash
+echo "some text" | cgip embedding
+```
+
+## Options
+
+- `[TEXT]`: Text to embed (optional, reads from stdin if not provided, or combines with stdin if both are present)
+- `--model <MODEL>`: Embedding model to use (default: text-embedding-3-small)
+- `--output <FILE>`: Write the embedding vector to a file instead of stdout
+
+The output is a comma-separated list of floating point numbers representing the embedding vector.

--- a/docs/cgip.1
+++ b/docs/cgip.1
@@ -43,6 +43,9 @@ Analyze images using vision-capable models. Requires the \fB--file\fR option to 
 .TP
 \fBtts\fR
 Convert text to speech using OpenAI's TTS models. Text can be provided as an argument, read from stdin, or both (stdin and argument text are combined). Supports various voices (alloy, echo, fable, onyx, nova, shimmer) and audio formats (mp3, opus, aac, flac). Speed can be adjusted from 0.25 to 4.0.
+.TP
+\fBembedding\fR
+Generate embeddings for text using OpenAI's embeddings endpoint. Provide text as an argument or via stdin. Use \fB--output\fR to write the vector to a file.
 .SH ARGUMENTS
 .TP
 \fB[QUERY]\fR
@@ -134,6 +137,16 @@ To combine stdin and argument text:
 .P
 .RS
 hostname | \fBcgip tts\fR "and that's all she wrote" --output combined.mp3
+.RE
+To generate embeddings for text:
+.P
+.RS
+\fBcgip embedding\fR "Hello world"
+.RE
+Save an embedding to a file:
+.P
+.RS
+echo "example" | \fBcgip embedding\fR --output vec.txt
 .RE
 .SH AUTHOR
 Written by Divan Visagie and Anna L. Smith.

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,9 +2,9 @@ use clap::{command, Parser};
 
 #[derive(Parser, Debug)]
 #[command(
-    author, 
-    version, 
-    about, 
+    author,
+    version,
+    about,
     long_about = r###"
 cgip is a command-line tool that leverages OpenAI's models to address and 
 respond to user queries. It compiles context for these queries by prioritizing 
@@ -22,9 +22,9 @@ Usage examples:
 "###
 )]
 pub struct Args {
-    /// Optional. The primary query to sent to the model. 
+    /// Optional. The primary query to sent to the model.
     /// This is added to the context after stdin and file input.
-    #[arg(index=1)]
+    #[arg(index = 1)]
     pub query: Option<String>,
 
     /// Read query from a file. If query is present this is added to the prompt after query.
@@ -39,20 +39,20 @@ pub struct Args {
     /// Specify model to use. Defaults to `gpt-4`.
     #[arg(short = 'M', long)]
     pub model: Option<String>,
-    
-    /// List all the available models. 
+
+    /// List all the available models.
     #[arg(short, long)]
-    pub list_models:bool,
+    pub list_models: bool,
 
     /// Show progress indicator (might mess up stdout).
     #[arg(short = 'p', long)]
     pub show_progress: bool,
-    
+
     /// Output the full context used in the query, including chat context with
     /// all assistant and user messages.
-    #[arg(short = 'c',long)]
+    #[arg(short = 'c', long)]
     pub show_context: bool,
-    
+
     /// Show context in human readable table
     #[arg(short, long)]
     pub markdown: bool,
@@ -64,9 +64,9 @@ pub struct Args {
     /// Speak like Jar Jar Binks
     #[arg(short, long)]
     pub jarjar: bool,
-    
+
     #[command(subcommand)]
-    pub subcmd: Option<SubCommands>
+    pub subcmd: Option<SubCommands>,
 }
 
 #[derive(Parser, Debug)]
@@ -85,8 +85,9 @@ pub enum SubCommands {
     Image(ImageSubCommand),
     /// Convert text to speech using OpenAI's TTS models.
     Tts(TtsSubCommand),
+    /// Generate embeddings for text using OpenAI's API.
+    Embedding(EmbeddingSubCommand),
 }
-
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -97,7 +98,7 @@ pub struct SessionSubCommand {
 
     /// View the current session context
     #[arg(short, long)]
-    pub view: bool
+    pub view: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -114,7 +115,7 @@ pub struct ConfigSubCommand {
     #[arg(short, long)]
     pub set: Option<String>,
 
-    /// Get your current configuration value. 
+    /// Get your current configuration value.
     /// `cgip config --get model`
     #[arg(short, long)]
     pub get: Option<String>,
@@ -166,4 +167,20 @@ pub struct TtsSubCommand {
     /// Speed of speech (0.25 to 4.0)
     #[arg(short, long, default_value = "1.0")]
     pub speed: f32,
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Generate embeddings for text", long_about = None)]
+pub struct EmbeddingSubCommand {
+    /// Text to generate embeddings for. If not provided, reads from stdin
+    #[arg(index = 1)]
+    pub text: Option<String>,
+
+    /// Embedding model to use
+    #[arg(short, long, default_value = "text-embedding-3-small")]
+    pub model: String,
+
+    /// Output file path. If not set, prints to stdout
+    #[arg(short, long)]
+    pub output: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,15 @@ fn select_and_execute(args: Args, client: &mut GptClient) {
         }
         return;
     }
-    
+
+    if let Some(SubCommands::Embedding(embed_sc)) = &args.subcmd {
+        if let Err(e) = sub::embedding::run(embed_sc) {
+            eprintln!("Embedding Error: {}", e);
+            std::process::exit(1);
+        }
+        return;
+    }
+
     if !args.no_session {
         let tty_context = read_from_tty_context();
         for msg in tty_context {

--- a/src/sub/embedding.rs
+++ b/src/sub/embedding.rs
@@ -1,0 +1,76 @@
+use reqwest::blocking::Client;
+use serde_json::json;
+use std::fs::File;
+use std::io::Write;
+
+use crate::args::EmbeddingSubCommand;
+use crate::utils::get_stdin;
+
+pub fn run(args: &EmbeddingSubCommand) -> Result<(), Box<dyn std::error::Error>> {
+    let stdin_text = get_stdin();
+    let text = match (stdin_text.is_empty(), &args.text) {
+        (true, None) => {
+            eprintln!("Error: No text provided. Please provide text as an argument or via stdin.");
+            std::process::exit(1);
+        }
+        (true, Some(arg_text)) => arg_text.clone(),
+        (false, None) => stdin_text,
+        (false, Some(arg_text)) => format!("{} {}", stdin_text, arg_text),
+    };
+
+    let api_key = std::env::var("OPENAI_API_KEY")
+        .map_err(|_| "Missing OPENAI_API_KEY environment variable")?;
+
+    let payload = json!({
+        "input": text,
+        "model": args.model,
+    });
+
+    let client = Client::new();
+
+    let base_url =
+        std::env::var("OPENAI_BASE_URL").unwrap_or_else(|_| "https://api.openai.com".to_string());
+    let url = if base_url.contains("/embeddings") {
+        base_url
+    } else if base_url.ends_with("/v1") {
+        format!("{}/embeddings", base_url)
+    } else {
+        format!("{}/v1/embeddings", base_url.trim_end_matches('/'))
+    };
+
+    let response = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .header("Content-Type", "application/json")
+        .json(&payload)
+        .send()?;
+
+    if !response.status().is_success() {
+        let error_text = response.text()?;
+        eprintln!("API Error: {}", error_text);
+        std::process::exit(1);
+    }
+
+    let resp_json: serde_json::Value = response.json()?;
+    let embedding = match resp_json["data"][0]["embedding"].as_array() {
+        Some(arr) => arr
+            .iter()
+            .map(|v| v.as_f64().unwrap_or(0.0).to_string())
+            .collect::<Vec<_>>()
+            .join(","),
+        None => {
+            eprintln!("Unexpected response format");
+            std::process::exit(1);
+        }
+    };
+
+    if let Some(path) = &args.output {
+        let mut file = File::create(path)?;
+        file.write_all(embedding.as_bytes())?;
+        println!("Embedding saved to: {}", path);
+    } else {
+        println!("{}", embedding);
+    }
+
+    Ok(())
+}

--- a/src/sub/mod.rs
+++ b/src/sub/mod.rs
@@ -1,5 +1,6 @@
-pub mod session;
 pub mod config;
-pub mod view;
+pub mod embedding;
 pub mod image;
+pub mod session;
 pub mod tts;
+pub mod view;


### PR DESCRIPTION
## Summary
- generate embeddings via `/v1/embeddings`
- provide `embedding` CLI subcommand
- document embedding usage and man page help

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68525671abc88331970b1c390743d358